### PR TITLE
Change syntax of mysql table creation query.

### DIFF
--- a/extension.driver.php
+++ b/extension.driver.php
@@ -222,7 +222,7 @@
 		 * {@inheritDoc}
 		 */
 		public function uninstall() {
-			Symphony::Database()->query("DROP TABLE `tbl_fields_order_entries`");
+			return Symphony::Database()->query("DROP TABLE IF EXISTS `tbl_fields_order_entries`");
 		}
 		
 		/**
@@ -294,7 +294,7 @@
 		 */
 		public function install() {
 			return Symphony::Database()->query("
-				CREATE TABLE `tbl_fields_order_entries` (
+				CREATE TABLE IF NOT EXISTS `tbl_fields_order_entries` (
 					`id` int(11) unsigned NOT NULL auto_increment,
 					`field_id` int(11) unsigned NOT NULL,
 					`force_sort` enum('yes','no') default 'no',
@@ -303,7 +303,7 @@
 					`filtered_fields` varchar(255) DEFAULT NULL,
 					PRIMARY KEY  (`id`),
 					UNIQUE KEY `field_id` (`field_id`)
-				) TYPE=MyISAM
+				) ENGINE=MyISAM;
 			");
 		}
 			


### PR DESCRIPTION
Changed table option from TYPE=MyISAM to ENGINE=MyISAM. Looking over ref manuals for older versions of MySQL, it seems both TYPE and ENGINE syntax was supported in ver 5.0, but TYPE was deprecated starting with ver 5.1. The TYPE syntax continued to work up until sometime in the last four years when either changes to symphony (2.7.7 -> 3.0.0) or the updates to the server s/w stack caused it to break. This change was unit tested on only one server config, so more testing and/or verification by a MySQL guru would be prudent.

Server config (shared host at pair networks):
* FreeBSD 12.3-RELEASE-p6
* Apache 2.4.54
* PHP Version 7.4.33
* mysql  Ver 14.14 Distrib 5.7.40, for FreeBSD12.3
